### PR TITLE
fix: remove yarn on prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:ci": "jest --ci --testResultsProcessor=\"./node_modules/jest-junit-reporter\" --coverage",
     "test": "jest",
     "test:watch": "yarn test --watch",
-    "prepare": "yarn build"
+    "prepare": "tsc -p tsconfigBuild.json"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
yarn should not be required to use this package as a dependency.
removing the call to yarn in the prepare step allows to install the package without having yarn installed globally